### PR TITLE
Fix typo & Update docker image tag

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -229,7 +229,7 @@ const VirtualBgSelector = ({
 
   const getLabel = () => {
     if (!isVirtualBackgroundSupported()) {
-      return deviceInfo.isIOS ? 'iOSは背景画像の変更に対応しておりません' : 'Safariは背景画像の変更に対応しておりません';
+      return deviceInfo.isIos ? 'iOS, iPadOSは背景画像の変更に対応しておりません' : 'Safariは背景画像の変更に対応しておりません';
     }
 
     return intl.formatMessage(intlMessages.virtualBackgroundSettingsLabel);

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -88,7 +88,7 @@ const isVirtualBackgroundEnabled = () => {
 }
 
 const isVirtualBackgroundSupported = () => {
-  return !(deviceInfo.isIOS || browserInfo.isSafari);
+  return !(deviceInfo.isIos || browserInfo.isSafari);
 }
 
 const getVirtualBgImagePath = () => {

--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 NAME="bbb-dev-01"  # change here if you want a different name
 HOSTNAME="${NAME}.test"
-IMAGE=imdt/bigbluebutton:2.4.x-develop
+IMAGE=imdt/bigbluebutton:2.4.x-develop_build_486
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 # retag the commit to force a lookup but keep in cache


### PR DESCRIPTION
**Reference PRs**
#4 

**Changes**
- deviceInfo.isIosのタイポを修正
    - BBBのrepoでは[2021/10/27のコミット](https://github.com/bigbluebutton/bigbluebutton/commit/35cac1eb8eba615789badd56694b6157565ef1c0)で修正済み
- create_bbb.shで使用するdockerイメージのタグをアップデート
    - 詳細は以下を参照